### PR TITLE
feat: agregar 10 vehículos al ejecutar comando seed

### DIFF
--- a/database/seeders/DatabaseSeeder.php
+++ b/database/seeders/DatabaseSeeder.php
@@ -14,5 +14,6 @@ class DatabaseSeeder extends Seeder
     {
         $this->call(RolesSeeder::class);
         $this->call(UsuariosSeeder::class);
+        $this->call([VehiculosSeeder::class,]);
     }
 }

--- a/database/seeders/VehiculosSeeder.php
+++ b/database/seeders/VehiculosSeeder.php
@@ -1,0 +1,90 @@
+<?php
+
+namespace Database\Seeders;
+
+use Illuminate\Database\Seeder;
+use App\Models\Vehiculo;
+use Faker\Factory as Faker;
+
+class VehiculosSeeder extends Seeder
+{
+    public function run(): void
+    {
+        $vehiculos = [
+            [
+                'placa' => 'P123-456',
+                'marca' => 'Toyota',
+                'modelo' => 'Corolla',
+                'año' => 2020,
+                'estado' => 'activo',
+            ],
+            [
+                'placa' => 'P234-567',
+                'marca' => 'Honda',
+                'modelo' => 'Civic',
+                'año' => 2019,
+                'estado' => 'activo',
+            ],
+            [
+                'placa' => 'P345-678',
+                'marca' => 'Nissan',
+                'modelo' => 'Sentra',
+                'año' => 2021,
+                'estado' => 'inactivo',
+            ],
+            [
+                'placa' => 'P456-789',
+                'marca' => 'Mazda',
+                'modelo' => '3',
+                'año' => 2022,
+                'estado' => 'activo',
+            ],
+            [
+                'placa' => 'P567-890',
+                'marca' => 'Ford',
+                'modelo' => 'Focus',
+                'año' => 2018,
+                'estado' => 'inactivo',
+            ],
+            [
+                'placa' => 'P678-901',
+                'marca' => 'Toyota',
+                'modelo' => 'Hilux',
+                'año' => 2017,
+                'estado' => 'activo',
+            ],
+            [
+                'placa' => 'P789-012',
+                'marca' => 'Chevrolet',
+                'modelo' => 'Cruze',
+                'año' => 2016,
+                'estado' => 'inactivo',
+            ],
+            [
+                'placa' => 'P890-123',
+                'marca' => 'Kia',
+                'modelo' => 'Rio',
+                'año' => 2020,
+                'estado' => 'activo',
+            ],
+            [
+                'placa' => 'P901-234',
+                'marca' => 'Hyundai',
+                'modelo' => 'Elantra',
+                'año' => 2023,
+                'estado' => 'activo',
+            ],
+            [
+                'placa' => 'P012-345',
+                'marca' => 'Volkswagen',
+                'modelo' => 'Jetta',
+                'año' => 2021,
+                'estado' => 'inactivo',
+            ],
+        ];
+
+        foreach ($vehiculos as $vehiculo) {
+            Vehiculo::create($vehiculo);
+        }
+    }
+}


### PR DESCRIPTION
Agrega el seeder VehiculosSeeder con 10 registros de vehículos reales.

- Los estados de los vehículos están restringidos a "activo" o "inactivo".
- Las placas siguen el formato oficial de El Salvador (P123-456).
- Los datos son coherentes y listos para pruebas funcionales o visualización en vistas.

Además, se actualizó DatabaseSeeder.php para incluir este seeder en la ejecución global de php artisan db:seed